### PR TITLE
Refactor: 기록 세부 조회, 월별 캘린더 API 

### DIFF
--- a/relayRun/src/main/java/com/example/relayRun/record/controller/RunningRecordController.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/controller/RunningRecordController.java
@@ -89,8 +89,8 @@ public class RunningRecordController {
     }
 
     // 하루 기록 조회
-    @ApiOperation(value="개인 기록 일별 요약", notes="bearer에 조회할 유저의 토큰, query에 조회 날짜를 입력해주세요 ex record/daily/?date=2023-01-26")
-    @GetMapping("/daily")
+    @ApiOperation(value="개인 기록 일별 요약", notes="bearer에 조회할 유저의 토큰, query에 조회 날짜를 입력해주세요 ex record/summary/?date=2023-01-26")
+    @GetMapping("/summary")
     public BaseResponse<GetDailyRes> getDailyRecord(Principal principal,
                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         try {
@@ -102,7 +102,7 @@ public class RunningRecordController {
     }
 
     @ApiOperation(value="그룹 기록 일별 요약", notes="조회할 그룹 idx를 입력해주세요, query에 조회 날짜를 입력해주세요 ex record/daily/{clubIdx}/?date=2023-01-27")
-    @GetMapping("/daily/{clubIdx}/club")
+    @GetMapping("/summary/{clubIdx}/club")
     public BaseResponse<GetDailyRes> getDailyGroup(@PathVariable("clubIdx") Long idx, @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         try {
             GetDailyRes dailyGroup = runningRecordService.getDailyGroup(idx, date);
@@ -112,11 +112,11 @@ public class RunningRecordController {
         }
     }
 
-    @ApiOperation(value="해당되는 월의 날짜별 개인 기록 요약", notes="bearer에 조회할 유저의 토큰, query에 년과 월을 입력해주세요 ex record/summary/?year=2023&month=1")
-    @GetMapping("/summary")
-    public BaseResponse<List<GetDailyRes>> getCalender(Principal principal, @RequestParam("year") Integer year, @RequestParam("month") Integer month) {
+    @ApiOperation(value="해당되는 월의 날짜별 개인 기록 모음", notes="bearer에 조회할 유저의 토큰, query에 년과 월을 입력해주세요 ex record/calender/?year=2023&month=1")
+    @GetMapping("/calender")
+    public BaseResponse<List<GetCalender>> getCalender(Principal principal, @RequestParam("year") Integer year, @RequestParam("month") Integer month) {
         try {
-            List<GetDailyRes> calender = runningRecordService.getCalender(principal, year, month);
+            List<GetCalender> calender = runningRecordService.getCalender(principal, year, month);
             return new BaseResponse<>(calender);
         } catch (BaseException e) {
             return new BaseResponse(e.getStatus());

--- a/relayRun/src/main/java/com/example/relayRun/record/controller/RunningRecordController.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/controller/RunningRecordController.java
@@ -79,9 +79,9 @@ public class RunningRecordController {
     // 기록 세부 조회
     @ApiOperation(value="기록 idx로 조회", notes="path variable에 조회할 기록의 idx를 입력해주세요")
     @GetMapping("/{idx}")
-    public BaseResponse<GetRecordByIdxRes> getRecordByIdx(@PathVariable("idx") Long idx) {
+    public BaseResponse<GetRecordByIdxRes> getRecordByIdx(Principal principal, @PathVariable("idx") Long idx) {
         try {
-            GetRecordByIdxRes rec = runningRecordService.getRecordByIdx(idx);
+            GetRecordByIdxRes rec = runningRecordService.getRecordByIdx(principal, idx);
             return new BaseResponse<>(rec);
         } catch (BaseException e) {
             return new BaseResponse(e.getStatus());

--- a/relayRun/src/main/java/com/example/relayRun/record/dto/GetCalender.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/dto/GetCalender.java
@@ -1,0 +1,22 @@
+package com.example.relayRun.record.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+public class GetCalender {
+    Long recordIdx;
+
+    @JsonFormat(pattern="yyyy-MM-dd")
+    LocalDate date;
+
+    float totalTime;
+
+    float totalDist;
+
+    float avgPace;
+}

--- a/relayRun/src/main/java/com/example/relayRun/record/dto/GetRecordByIdxRes.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/dto/GetRecordByIdxRes.java
@@ -13,6 +13,10 @@ import java.util.List;
 public class GetRecordByIdxRes {
     private Long recordIdx;
 
+    private String nickName;
+
+    private String clubName;
+
     @JsonFormat(pattern="yyyy-MM-dd HH:mm:ss")
     private LocalDateTime date;
 

--- a/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
@@ -315,7 +315,7 @@ public class RunningRecordService {
      * @return
      * @throws BaseException
      */
-    public List<GetDailyRes> getCalender(Principal principal, Integer year, Integer month) throws BaseException {
+    public List<GetCalender> getCalender(Principal principal, Integer year, Integer month) throws BaseException {
         try {
             // principal에서 user 가져오기
             Optional<UserEntity> user = userRepository.findByEmail(principal.getName());
@@ -330,11 +330,12 @@ public class RunningRecordService {
             // memberStatus에 해당하는 기록 중 해당 월만 갖고오기
             List<RunningRecordEntity> recordList = runningRecordRepository.selectByMemberStatusAndYearAndMonthAndStatus(applyList, year, month, "active");
 
-            // GetDailyRes로 변환
-            List<GetDailyRes> calender = new ArrayList<>();
+            // GetCalender로 변환
+            List<GetCalender> calender = new ArrayList<>();
             for (RunningRecordEntity record : recordList) {
                 calender.add(
-                        GetDailyRes.builder()
+                        GetCalender.builder()
+                                .recordIdx(record.getRunningRecordIdx())
                                 .date(record.getCreatedAt().toLocalDate())
                                 .totalTime(record.getTime())
                                 .totalDist(record.getDistance())

--- a/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
@@ -215,6 +215,8 @@ public class RunningRecordService {
 
             return GetRecordByIdxRes.builder()
                     .recordIdx(idx)
+                    .nickName(record.get().getMemberStatusIdx().getUserProfileIdx().getNickName())
+                    .clubName(record.get().getMemberStatusIdx().getClubIdx().getName())
                     .date(record.get().getCreatedAt())
                     .time(record.get().getTime())
                     .distance(record.get().getDistance())


### PR DESCRIPTION
이전에 완료했던 API들 조금 보완해서 pr 만들었습니다!

반환 값 수정
- 인덱스로 기록 조회
	- 기록별 닉네임/당시 소속팀 이름 추가
	- principal을 받아 개인의 기록일때만 location 반환
	- principal이 없거나 다른 사람이면 location 뺀 정보들 반환
- 캘린더 보기
	- 기록 인덱스 추가
	- 프론트에서 캘린더 그래프 그릴 때는 날짜별 수치 활용
	- 날짜 클릭시 조회 페이지는 날짜에 해당하는 인덱스 할당 -> 인덱스로 기록 조회로 넘어가기

URI 수정
- 일별 요약(개인, 그룹)
	- 기존 record/daily -> **record/summary**
	- 개인 기록 요약 record/summary/?date=yyyy-mm-dd
	- 그룹 기록 요약 record/summary/{clubIdx}/club/?date=yyyy-mm-dd
- 캘린더 보기
	- 기존 record/summary -> **record/calender**
	- 예시 record/calender/?year=2023&month=1