### PR TITLE
Fix: 이메일 인증하기 API

### DIFF
--- a/relayRun/src/main/java/com/example/relayRun/user/controller/UserController.java
+++ b/relayRun/src/main/java/com/example/relayRun/user/controller/UserController.java
@@ -163,7 +163,7 @@ public class UserController {
     }
 
     @ResponseBody
-    @GetMapping("/emailConfirm")
+    @PostMapping("/emailConfirm")
     @ApiOperation(value="인증 번호 비교", notes="이메일로 발급받으신 인증번호를 RequestBody에 넣어서 String으로 인증번호 인증 성공/실패 여부 반환하도록 했습니다!")
     public BaseResponse<String> confirmEmail(Principal principal, @RequestBody GetEmailCodeReq code) throws BaseException {
         if (this.userService.confirmEmail(principal, code)){

--- a/relayRun/src/main/java/com/example/relayRun/user/controller/UserController.java
+++ b/relayRun/src/main/java/com/example/relayRun/user/controller/UserController.java
@@ -154,7 +154,8 @@ public class UserController {
     }
     @ResponseBody
     @PostMapping("/email")
-    @ApiOperation(value="인증 번호 이메일 발급", notes="네이버 메일 (@naver.com) 형식의 이메일만 메일 전송이 가능합니다. 인증 번호 유효 시간은 5분으로, 시간이 지나면 코드는 삭제됩니다!")
+    @ApiOperation(value="인증 번호 이메일 발급", notes="bearer에 토큰을 넣어주시면 가입된 이메일로 인증 메일이 전송됩니다. 인증 번호 유효 시간은 5분으로, 시간이 지나면 코드는 삭제됩니다!\n" +
+            "네이버 메일 (@naver.com) 형식의 이메일만 발신자로 설정이 가능하고, 이 주소는 서버측에 문의 후 넣어주세요.")
     public BaseResponse<String> authEmail(Principal principal, @RequestBody @Valid PostEmailReq request) throws Exception {
         String code = this.userService.sendSimpleMessage(principal, request.getEmail());
         log.info("인증 코드 : " + code);

--- a/relayRun/src/main/java/com/example/relayRun/user/dto/PostEmailReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/user/dto/PostEmailReq.java
@@ -8,6 +8,6 @@ import javax.validation.constraints.Email;
 @Data
 public class PostEmailReq {
     @Email
-    @ApiModelProperty(example = "인증 번호 보낼 이메일")
+    @ApiModelProperty(example = "이메일 발신자, 서버에게 문의해주세요")
     private String email;
 }

--- a/relayRun/src/main/java/com/example/relayRun/user/service/UserService.java
+++ b/relayRun/src/main/java/com/example/relayRun/user/service/UserService.java
@@ -53,7 +53,6 @@ public class UserService {
     private RedisUtil redisUtil;
 
     private final String ePw = createKey();
-    private String id = "codusl100@naver.com";
 
 
     public UserService(UserRepository userRepository, UserProfileRepository userProfileRepository,
@@ -308,7 +307,7 @@ public class UserService {
             userProfileRepository.save(UserProfile);
         }
     }
-    public MimeMessage createMessage(String to)throws MessagingException, UnsupportedEncodingException {
+    public MimeMessage createMessage(String from, String to) throws MessagingException, UnsupportedEncodingException {
         log.info("보내는 대상 : "+ to);
         log.info("인증 번호 : " + ePw);
         MimeMessage  message = javaMailSender.createMimeMessage();
@@ -324,7 +323,7 @@ public class UserService {
         msg += "</td></tr></tbody></table></div>";
 
         message.setText(msg, "utf-8", "html"); //내용, charset타입, subtype
-        message.setFrom(new InternetAddress(id,"이어달리기 팀")); //보내는 사람의 메일 주소, 보내는 사람 이름
+        message.setFrom(new InternetAddress(from,"이어달리기 팀")); //보내는 사람의 메일 주소, 보내는 사람 이름
 
         return message;
     }
@@ -341,7 +340,7 @@ public class UserService {
     }
 
     // 메일 발송
-    public String sendSimpleMessage(Principal principal, String to)throws Exception {
+    public String sendSimpleMessage(Principal principal, String from)throws Exception {
         Optional<UserEntity> optionalUserEntity = userRepository.findByEmail(principal.getName());
         if(optionalUserEntity.isEmpty()) {
             throw new BaseException(BaseResponseStatus.FAILED_TO_LOGIN);
@@ -356,12 +355,13 @@ public class UserService {
             userProfileRepository.save(UserProfile);
         }
         MimeMessage message = createMessage(to);
-        String email = optionalUserEntity.get().getEmail();
+        String to = optionalUserEntity.get().getEmail();
+        MimeMessage message = createMessage(from, to);
         try{
             javaMailSender.send(message); // 메일 발송
             //    Redis로 유효기간 설정하기
             // 유효 시간(5분)동안 {email, authKey} 저장
-            redisUtil.setDataExpire(ePw, email, 60 * 5L);
+            redisUtil.setDataExpire(ePw, to, 60 * 5L);
         }catch(MailException es){
             es.printStackTrace();
             throw new IllegalArgumentException();

--- a/relayRun/src/main/java/com/example/relayRun/user/service/UserService.java
+++ b/relayRun/src/main/java/com/example/relayRun/user/service/UserService.java
@@ -346,7 +346,7 @@ public class UserService {
         if(optionalUserEntity.isEmpty()) {
             throw new BaseException(BaseResponseStatus.FAILED_TO_LOGIN);
         }
-        UserProfileEntity UserProfile = userProfileRepository.findByUserProfileIdx(optionalUserEntity.get().getUserIdx()).get();
+        UserProfileEntity UserProfile = userProfileRepository.findByUserIdx(optionalUserEntity.get()).get();
         if (UserProfile.getIsAlarmOn().equals("y")) {
             UserProfile.setIsAlarmOn("n");
             userProfileRepository.save(UserProfile);

--- a/relayRun/src/main/java/com/example/relayRun/user/service/UserService.java
+++ b/relayRun/src/main/java/com/example/relayRun/user/service/UserService.java
@@ -52,8 +52,6 @@ public class UserService {
 
     private RedisUtil redisUtil;
 
-    private final String ePw = createKey();
-
 
     public UserService(UserRepository userRepository, UserProfileRepository userProfileRepository,
                        PasswordEncoder passwordEncoder, TokenProvider tokenProvider, RefreshTokenRepository refreshTokenRepository,
@@ -307,7 +305,7 @@ public class UserService {
             userProfileRepository.save(UserProfile);
         }
     }
-    public MimeMessage createMessage(String from, String to) throws MessagingException, UnsupportedEncodingException {
+    public MimeMessage createMessage(String from, String to, String ePw) throws MessagingException, UnsupportedEncodingException {
         log.info("보내는 대상 : "+ to);
         log.info("인증 번호 : " + ePw);
         MimeMessage  message = javaMailSender.createMimeMessage();
@@ -354,9 +352,9 @@ public class UserService {
             UserProfile.setIsAlarmOn("y");
             userProfileRepository.save(UserProfile);
         }
-        MimeMessage message = createMessage(to);
+        String ePw = createKey(); // 새로운 코드 발급
         String to = optionalUserEntity.get().getEmail();
-        MimeMessage message = createMessage(from, to);
+        MimeMessage message = createMessage(from, to, ePw);
         try{
             javaMailSender.send(message); // 메일 발송
             //    Redis로 유효기간 설정하기
@@ -377,7 +375,7 @@ public class UserService {
         }
         String user = redisUtil.getData(code.getCode());
         log.info("유저 정보 : " + user);
-        if (user == null || user.length() == 0) {
+        if (user == null || user.length() == 0 || !user.equals(optionalUserEntity.get().getEmail())) {
             return false;
         }
         return true;


### PR DESCRIPTION
- NoSuchElementException 해결
	- 유저 idx로 프로필을 찾도록 변경

- 메일 전송 프로세스 변경
	- 수신자는 principal로 받은 유저의 이메일로 자동 지정
	- body로는 발신자를 입력받도록 수정 (원래는 수신자)
	- 이때 이 발신자는 네이버 전체 아이디어야 하고, 계정 정보를 application-secret에 업데이트 해줘야함

- 인증번호 확인 프로세스 보완
	- 매 요청 시 새로운 코드 발급되도록 수정
	- 자기 자신에 해당되는 코드인지 추가 검증
	- 이 부분 테스트를 원하시면 redis를 까셔야 합니다..! 전송은 안깔려있어도 가능해요

+) 저희 팀 구글 계정 그냥 보안 단계 높여버리고 얘로 발신자 고정시켜놓을까요...? 어차피 저희가 직접 구글 계정에 접속할 일은 적을 것 같아서 로그인 조금 힘들어져도 괜찮을 것 같다는 생각입니다..!
