### PR TITLE
멤버 강퇴 API

### DIFF
--- a/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
@@ -3,6 +3,7 @@ package com.example.relayRun.club.controller;
 import com.example.relayRun.club.dto.GetClubDetailRes;
 import com.example.relayRun.club.dto.GetClubListRes;
 import com.example.relayRun.club.dto.GetMemberOfClubRes;
+import com.example.relayRun.club.dto.PatchDeleteMemberReq;
 import com.example.relayRun.club.service.ClubService;
 import com.example.relayRun.club.service.MemberStatusService;
 import com.example.relayRun.record.service.RunningRecordService;
@@ -12,6 +13,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -72,6 +74,18 @@ public class ClubController {
             GetClubDetailRes getClubDetailRes = clubService.getClubDetail(clubIdx);
             getClubDetailRes.setGetMemberOfClubResList(getMemberOfClub(clubIdx, date).getResult());
             return new BaseResponse<>(getClubDetailRes);
+        } catch(BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    @ApiOperation(value="멤버 강퇴", notes="")
+    @ResponseBody
+    @PatchMapping("/{clubIdx}/members/deletion")
+    public BaseResponse<String> deleteMember(Principal principal, @PathVariable Long clubIdx, PatchDeleteMemberReq request) {
+        try {
+            String userProfileName = clubService.deleteClubMember(principal, clubIdx, request);
+            return new BaseResponse<>(userProfileName + "이(가) 강퇴되었습니다.");
         } catch(BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PatchDeleteMemberReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PatchDeleteMemberReq.java
@@ -1,0 +1,17 @@
+package com.example.relayRun.club.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ApiModel(value = "멤버 강퇴 모델")
+public class PatchDeleteMemberReq {
+    @ApiModelProperty(example = "강퇴 유저 프로필 idx", required = true)
+    private Long userProfileIdx;
+}

--- a/relayRun/src/main/java/com/example/relayRun/club/entity/MemberStatusEntity.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/entity/MemberStatusEntity.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 @Table(name = "member_status")

--- a/relayRun/src/main/java/com/example/relayRun/club/repository/MemberStatusRepository.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/repository/MemberStatusRepository.java
@@ -19,7 +19,7 @@ public interface MemberStatusRepository extends JpaRepository<MemberStatusEntity
 
     List<MemberStatusEntity> findByClubIdx_ClubIdx(Long clubIdx);
 
-    List<MemberStatusEntity> findAllByClubIdx_ClubIdxAndApplyStatus(Long clubIdx, String applyStatus);
+    List<MemberStatusEntity> findAllByClubIdx_ClubIdxAndApplyStatusAndStatus(Long clubIdx, String applyStatus, String status);
 
     @Query(value = "select * from member_status where user_profile_idx = :userProfileIdx limit 1", nativeQuery = true)
     MemberStatusEntity findByUserProfileIdx(Long userProfileIdx);

--- a/relayRun/src/main/java/com/example/relayRun/club/repository/MemberStatusRepository.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/repository/MemberStatusRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Repository
 public interface MemberStatusRepository extends JpaRepository<MemberStatusEntity, Long> {
     List<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndStatus(Long userProfileIdx, String status);
+    Optional<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndApplyStatusAndStatus(Long userProfileIdx, String applyStatus, String status);
     Optional<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndApplyStatusIs(Long ProfileIdx, String applyStatus);
     @Query(value = "select member_status_idx from member_status where club_idx = :clubIdx", nativeQuery = true)
     List<Long> selectMemberStatusIdxList(@Param(value = "clubIdx") Long clubIdx);

--- a/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
@@ -3,7 +3,6 @@ package com.example.relayRun.club.service;
 import com.example.relayRun.club.dto.*;
 import com.example.relayRun.club.entity.ClubEntity;
 import com.example.relayRun.club.entity.MemberStatusEntity;
-import com.example.relayRun.club.entity.TimeTableEntity;
 import com.example.relayRun.club.repository.ClubRepository;
 import com.example.relayRun.club.repository.MemberStatusRepository;
 import com.example.relayRun.club.repository.TimeTableRepository;
@@ -14,16 +13,11 @@ import com.example.relayRun.user.repository.UserProfileRepository;
 import com.example.relayRun.user.repository.UserRepository;
 import com.example.relayRun.util.BaseException;
 import com.example.relayRun.util.BaseResponseStatus;
-import org.jsoup.Connection;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.Principal;
 import java.util.ArrayList;
-import java.sql.Time;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
@@ -67,7 +61,7 @@ public class ClubService {
 
     public List<GetMemberOfClubRes> getMemberOfClub(Long clubIdx) throws BaseException {
         try {
-            List<MemberStatusEntity> memberStatusEntityList = memberStatusRepository.findAllByClubIdx_ClubIdxAndApplyStatus(clubIdx, "ACCEPTED");
+            List<MemberStatusEntity> memberStatusEntityList = memberStatusRepository.findAllByClubIdx_ClubIdxAndApplyStatusAndStatus(clubIdx, "ACCEPTED", "active");
             if (memberStatusEntityList.isEmpty()) {
                 throw new BaseException(BaseResponseStatus.FAILED_TO_SEARCH);
             }

--- a/relayRun/src/main/java/com/example/relayRun/user/repository/UserProfileRepository.java
+++ b/relayRun/src/main/java/com/example/relayRun/user/repository/UserProfileRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 @Repository
 public interface UserProfileRepository extends JpaRepository<UserProfileEntity, Long> {
     Optional<UserProfileEntity> findByUserProfileIdx(Long userProfileIdx);
+    Optional<UserProfileEntity> findByUserProfileIdxAndStatus(Long userProfileIdx, String status);
     List<UserProfileEntity> findAllByUserIdx(UserEntity user);
     List<UserProfileEntity> findAllByUserIdxAndStatus(UserEntity user, String status);
     Optional<UserProfileEntity> findByUserIdx(UserEntity user);

--- a/relayRun/src/main/java/com/example/relayRun/util/BaseResponseStatus.java
+++ b/relayRun/src/main/java/com/example/relayRun/util/BaseResponseStatus.java
@@ -70,6 +70,7 @@ public enum BaseResponseStatus {
      * 7000 : PATCH
      * */
     PATCH_PASSWORD_CHECK_WRONG(false, 7000, "비밀번호 확인란을 다시 확인해주세요."),
+    PATCH_NOT_HOST(false, 7001, "해당 그룹의 방장이 아닙니다."),
 
     /*
      * 8000 : delete


### PR DESCRIPTION
강퇴시 해당 member_status > status 값을 inactive로 전환합니다

이에 따라 그룹 멤버 조회할 때도 status를 기반으로 조회하도록 했어요!

- principal로 유저 검증
- 해당 그룹이 있는지 확인
- 해당 그룹의 방장인지 확인
- 삭제하고자 하는 프로필이 해당 그룹의 멤버인지 확인