### PR TITLE
Issue 81

### DIFF
--- a/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
@@ -10,7 +10,6 @@ import io.swagger.annotations.*;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -24,7 +23,9 @@ public class ClubController {
     private final MemberStatusService memberStatusService;
     private final RunningRecordService runningRecordService;
 
-    public ClubController(ClubService clubService, MemberStatusService memberStatusService, RunningRecordService runningRecordService) {
+    public ClubController(ClubService clubService,
+                          MemberStatusService memberStatusService,
+                          RunningRecordService runningRecordService) {
         this.clubService = clubService;
         this.memberStatusService = memberStatusService;
         this.runningRecordService = runningRecordService;
@@ -33,18 +34,11 @@ public class ClubController {
     @ApiOperation(value="메인 페이지", notes="헤더로 access 토큰, path variable로 userProfileIdx를 보내주세요.")
     @ResponseBody
     @GetMapping("/home/{userProfileIdx}")
-    public BaseResponse<List<GetMemberOfClubRes>> getHome(Principal principal,
-                                                          @ApiParam(value = "조회하고자 하는 유저의 userProfileIdx")@PathVariable Long userProfileIdx) {
+    public BaseResponse<List<GetMemberOfClubRes>> getHome(
+            Principal principal,
+            @ApiParam(value = "조회하고자 하는 유저의 userProfileIdx")@PathVariable Long userProfileIdx) {
         try {
-            Long clubIdx = clubService.getClubIdx(principal, userProfileIdx);
-            List<GetMemberOfClubRes> getMemberOfClubResList = clubService.getMemberOfClub(clubIdx);
-            for(GetMemberOfClubRes getMemberOfClubRes : getMemberOfClubResList) {
-                LocalDate date = LocalDate.now();
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-                LocalDateTime startDate = LocalDateTime.parse(date + " 00:00:00", formatter);
-                LocalDateTime endDate = LocalDateTime.parse(date + " 23:59:59", formatter);
-                getMemberOfClubRes.setRunningRecord(runningRecordService.getRecordWithoutLocation(getMemberOfClubRes.getMemberStatusIdx(), startDate, endDate));
-            }
+            List<GetMemberOfClubRes> getMemberOfClubResList = clubService.getHome(principal, userProfileIdx);
             return new BaseResponse<>(getMemberOfClubResList);
         } catch(BaseException e) {
             return new BaseResponse<>(e.getStatus());

--- a/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
@@ -125,8 +125,7 @@ public class ClubController {
     @GetMapping("/{clubIdx}")
     public BaseResponse<GetClubDetailRes> getClubDetail(
             @ApiParam(value = "조회하고자 하는 그룹의 clubIdx")@PathVariable Long clubIdx,
-            @ApiParam(value = "조회하고자 하는 날짜")@RequestParam("date") String date
-    ) {
+            @ApiParam(value = "조회하고자 하는 날짜")@RequestParam("date") String date) {
         try {
             GetClubDetailRes getClubDetailRes = clubService.getClubDetail(clubIdx);
             getClubDetailRes.setGetMemberOfClubResList(getMemberOfClub(clubIdx, date).getResult());

--- a/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
@@ -49,8 +49,7 @@ public class ClubController {
     @ResponseBody
     @GetMapping("")
     public BaseResponse<List<GetClubListRes>> getClubs(
-            @ApiParam(value = "그룹 검색어")@RequestParam(required = false) String search
-    ) {
+            @ApiParam(value = "그룹 검색어")@RequestParam(required = false) String search) {
         try {
             List<GetClubListRes> clubList;
             if(search == null) {
@@ -64,7 +63,6 @@ public class ClubController {
         }
     }
 
-    // 그룹 생성
     @ResponseBody
     @PostMapping("")
     @ApiResponses({

--- a/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.security.Principal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -41,7 +42,12 @@ public class ClubController {
             Principal principal,
             @ApiParam(value = "조회하고자 하는 유저의 userProfileIdx") @PathVariable Long userProfileIdx) {
         try {
-            List<GetMemberOfClubRes> getMemberOfClubResList = clubService.getHome(principal, userProfileIdx);
+            Long clubIdx = clubService.getClubIdx(principal, userProfileIdx);
+            List<GetMemberOfClubRes> getMemberOfClubResList = clubService.getMemberOfClub(clubIdx);
+            for(GetMemberOfClubRes getMemberOfClubRes : getMemberOfClubResList) {
+                LocalDate date = LocalDate.now();
+                getMemberOfClubRes.setRunningRecord(runningRecordService.getRecordWithoutLocation(getMemberOfClubRes.getMemberStatusIdx(), date.atStartOfDay(), date.plusDays(1).atStartOfDay()));
+            }
             return new BaseResponse<>(getMemberOfClubResList);
         } catch(BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -99,8 +105,7 @@ public class ClubController {
     @GetMapping("/{clubIdx}/members")
     public BaseResponse<List<GetMemberOfClubRes>> getMemberOfClub(
             @ApiParam(value = "조회하고자 하는 그룹의 clubIdx")@PathVariable Long clubIdx,
-            @ApiParam(value = "조회하고자 하는 날짜")@RequestParam("date") String date
-    ) {
+            @ApiParam(value = "조회하고자 하는 날짜")@RequestParam("date") String date) {
         try {
             List<GetMemberOfClubRes> getMemberOfClubResList = clubService.getMemberOfClub(clubIdx);
             for(GetMemberOfClubRes getMemberOfClubRes : getMemberOfClubResList) {

--- a/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
@@ -40,7 +40,8 @@ public class ClubController {
     @GetMapping("/home/{userProfileIdx}")
     public BaseResponse<List<GetMemberOfClubRes>> getHome(
             Principal principal,
-            @ApiParam(value = "조회하고자 하는 유저의 userProfileIdx") @PathVariable Long userProfileIdx) {
+            @ApiParam(value = "조회하고자 하는 유저의 userProfileIdx") @PathVariable Long userProfileIdx
+    ) {
         try {
             Long clubIdx = clubService.getClubIdx(principal, userProfileIdx);
             List<GetMemberOfClubRes> getMemberOfClubResList = clubService.getMemberOfClub(clubIdx);
@@ -86,7 +87,8 @@ public class ClubController {
     public BaseResponse<String> makeClub(
             Principal principal,
             @ApiParam(value = "그룹 생성에 필요한 request body 정보") @Valid @RequestBody PostClubReq clubReq,
-            BindingResult bindingResult) {
+            BindingResult bindingResult
+    ) {
         try {
             if (bindingResult.hasErrors()) {
 //                ObjectError objectError = bindingResult.getAllErrors().stream().findFirst().get();
@@ -105,7 +107,8 @@ public class ClubController {
     @GetMapping("/{clubIdx}/members")
     public BaseResponse<List<GetMemberOfClubRes>> getMemberOfClub(
             @ApiParam(value = "조회하고자 하는 그룹의 clubIdx")@PathVariable Long clubIdx,
-            @ApiParam(value = "조회하고자 하는 날짜")@RequestParam("date") String date) {
+            @ApiParam(value = "조회하고자 하는 날짜")@RequestParam("date") String date
+    ) {
         try {
             List<GetMemberOfClubRes> getMemberOfClubResList = clubService.getMemberOfClub(clubIdx);
             for(GetMemberOfClubRes getMemberOfClubRes : getMemberOfClubResList) {
@@ -125,7 +128,8 @@ public class ClubController {
     @GetMapping("/{clubIdx}")
     public BaseResponse<GetClubDetailRes> getClubDetail(
             @ApiParam(value = "조회하고자 하는 그룹의 clubIdx")@PathVariable Long clubIdx,
-            @ApiParam(value = "조회하고자 하는 날짜")@RequestParam("date") String date) {
+            @ApiParam(value = "조회하고자 하는 날짜")@RequestParam("date") String date
+    ) {
         try {
             GetClubDetailRes getClubDetailRes = clubService.getClubDetail(clubIdx);
             getClubDetailRes.setGetMemberOfClubResList(getMemberOfClub(clubIdx, date).getResult());
@@ -188,8 +192,16 @@ public class ClubController {
     @ApiOperation(value="그룹 정보 변경 (방장만 가능)", notes="access 토큰, 그룹 식별자, 변경하고자 하는 그룹 정보 값 전체를 넘겨주세요")
     @ResponseBody
     @PatchMapping("/{clubIdx}")
-    public BaseResponse<String> patchClubInfo(Principal principal, @PathVariable("clubIdx") Long clubIdx, @RequestBody PatchClubInfoReq clubInfoReq){
+    public BaseResponse<String> patchClubInfo(
+            Principal principal,
+            @PathVariable("clubIdx") Long clubIdx,
+            @Valid @RequestBody PatchClubInfoReq clubInfoReq,
+            BindingResult bindingResult
+    ){
         try {
+            if (bindingResult.hasErrors()) {
+                throw new BaseException(BaseResponseStatus.VALIDATION_ERROR);
+            }
             clubService.updateClubInfo(principal, clubIdx, clubInfoReq);
             return new BaseResponse<>("그룹의 정보를 변경하였습니다.");
         } catch (BaseException e) {
@@ -200,7 +212,7 @@ public class ClubController {
     @ApiOperation(value="그룹 방장 위임", notes="path variable로 클럽 아이디를 전달하고 현재 프로필 아이디, 방장이 될 유저의 프로필 아이디를 body로 전달해주세요")
     @ResponseBody
     @PatchMapping("/{clubIdx}/host-change")
-    public BaseResponse<String> patchClubHost(Principal principal, @PathVariable("clubIdx") Long clubIdx, @RequestBody PatchHostReq hostReq) {
+    public BaseResponse<String> patchClubHost(Principal principal, @PathVariable("clubIdx") Long clubIdx, @Valid @RequestBody PatchHostReq hostReq) {
         try {
             clubService.updateClubHost(principal, clubIdx, hostReq);
             return new BaseResponse<>("방장을 위임 하였습니다.");

--- a/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
@@ -16,6 +16,7 @@ import java.security.Principal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
 @RestController
@@ -118,7 +119,9 @@ public class ClubController {
                 getMemberOfClubRes.setRunningRecord(runningRecordService.getRecordWithoutLocation(getMemberOfClubRes.getMemberStatusIdx(), startDate, endDate));
             }
             return new BaseResponse<>(getMemberOfClubResList);
-        } catch(BaseException e) {
+        } catch (DateTimeParseException e) {
+            return new BaseResponse<>(BaseResponseStatus.INVALID_DATE_FORMAT);
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -134,6 +137,8 @@ public class ClubController {
             GetClubDetailRes getClubDetailRes = clubService.getClubDetail(clubIdx);
             getClubDetailRes.setGetMemberOfClubResList(getMemberOfClub(clubIdx, date).getResult());
             return new BaseResponse<>(getClubDetailRes);
+        } catch (DateTimeParseException e) {
+            return new BaseResponse<>(BaseResponseStatus.INVALID_DATE_FORMAT);
         } catch(BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/relayRun/src/main/java/com/example/relayRun/club/controller/MemberStatusController.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/controller/MemberStatusController.java
@@ -25,10 +25,11 @@ public class MemberStatusController {
         this.memberStatusService = memberStatusService;
     }
 
-    @ApiOperation(value = "그룹 신청", notes = "path variable로 신청하고자 하는 그룹의 clubIdx, body로는 신청자의 userProfileIdx와 신청자의 시간표 정보를 리스트 형식으로 보내면 그룹 신청과 시간표 등록이 완료됩니다.")
+    @ApiOperation(value = "그룹 신청", notes = "헤더로 토큰, path variable로 신청하고자 하는 그룹의 clubIdx, body로는 신청자의 userProfileIdx와 신청자의 시간표 정보를 리스트 형식으로 보내면 그룹 신청과 시간표 등록이 완료됩니다.")
     @ResponseBody
     @PostMapping("/{clubIdx}")
     public BaseResponse<String> createMemberStatus(
+            Principal principal,
             @ApiParam(value = "신청하고자 하는 그룹의 clubIdx") @PathVariable Long clubIdx,
             @ApiParam(value = "신청자의 userProfileIdx과 시간표 정보") @Valid @RequestBody PostMemberStatusReq memberStatus,
             BindingResult bindingResult) {
@@ -36,7 +37,7 @@ public class MemberStatusController {
             if (bindingResult.hasErrors()) {
                 throw new BaseException(BaseResponseStatus.VALIDATION_ERROR);
             }
-            memberStatusService.createMemberStatus(clubIdx, memberStatus);
+            memberStatusService.createMemberStatus(principal, clubIdx, memberStatus);
             return new BaseResponse<>("그룹 신청 및 시간표 등록 완료");
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -55,24 +56,26 @@ public class MemberStatusController {
         }
     }
 
-    @ApiOperation(value = "개인 시간표 조회", notes = "path variable로 조회하고자 하는 유저의 userProfileIdx를 보내면 해당 유저의 시간표를 리스트 형식으로 반환합니다.")
+    @ApiOperation(value = "개인 시간표 조회", notes = "헤더로 토큰, path variable로 조회하고자 하는 유저의 userProfileIdx를 보내면 해당 유저의 시간표를 리스트 형식으로 반환합니다.")
     @ResponseBody
     @GetMapping("/time-tables/{userProfileIdx}")
     public BaseResponse<List<GetTimeTableListRes>> getUserTimeTable(
+            Principal principal,
             @ApiParam(value = "조회하고자 하는 유저의 userProfileIdx") @PathVariable Long userProfileIdx
 
     ) {
         try {
-            List<GetTimeTableListRes> timeTableList = memberStatusService.getUserTimeTable(userProfileIdx);
+            List<GetTimeTableListRes> timeTableList = memberStatusService.getUserTimeTable(principal, userProfileIdx);
             return new BaseResponse<>(timeTableList);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
     }
-    @ApiOperation(value = "시간표 수정", notes = "path variable로 수정하고자 하는 유저의 userProfileIdx, body로는 해당 유저의 시간표 정보를 리스트 형식으로 보내면 시간표 수정이 완료됩니다.")
+    @ApiOperation(value = "시간표 수정", notes = "헤더로 토큰, path variable로 수정하고자 하는 유저의 userProfileIdx, body로는 해당 유저의 시간표 정보를 리스트 형식으로 보내면 시간표 수정이 완료됩니다.")
     @ResponseBody
     @PostMapping("/time-tables/{userProfileIdx}")
     public BaseResponse<String> updateTimeTable(
+            Principal principal,
             @ApiParam(value = "수정하고자 하는 유저의 userProfileIdx") @PathVariable Long userProfileIdx,
             @ApiParam(value = "유저의 시간표 정보(리스트 형식)") @Valid @RequestBody PostTimeTableReq postTimeTableReq,
             BindingResult bindingResult
@@ -81,7 +84,7 @@ public class MemberStatusController {
             if (bindingResult.hasErrors()) {
                 throw new BaseException(BaseResponseStatus.VALIDATION_ERROR);
             }
-            memberStatusService.updateTimeTable(userProfileIdx, postTimeTableReq);
+            memberStatusService.updateTimeTable(principal, userProfileIdx, postTimeTableReq);
             return new BaseResponse<>("시간표 수정 완료");
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -94,7 +97,7 @@ public class MemberStatusController {
     public BaseResponse<String> leaveClub(
             Principal principal,
             @PathVariable Long clubIdx,
-            @RequestBody PatchDeleteMemberReq patchDeleteMemberReq) {
+            @Valid @RequestBody PatchDeleteMemberReq patchDeleteMemberReq) {
         try {
             Long userProfileIdx = patchDeleteMemberReq.getUserProfileIdx();
             memberStatusService.updateMemberStatus(principal, clubIdx, userProfileIdx);
@@ -110,7 +113,7 @@ public class MemberStatusController {
     public BaseResponse<String> deleteMember(
             Principal principal,
             @PathVariable Long clubIdx,
-            @RequestBody PatchDeleteMemberReq patchDeleteMemberReq) {
+            @Valid @RequestBody PatchDeleteMemberReq patchDeleteMemberReq) {
         try {
             String userProfileName = memberStatusService.deleteClubMember(principal, clubIdx, patchDeleteMemberReq);
             return new BaseResponse<>(userProfileName + "이(가) 강퇴되었습니다.");

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PatchClubInfoReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PatchClubInfoReq.java
@@ -39,7 +39,6 @@ public class PatchClubInfoReq {
     private GoalType goalType;
 
     @ApiModelProperty(example="목표 km")
-    @Positive
     private Float goal;
 
     @ApiModelProperty(value = "변경할 모집 상태")

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PatchClubInfoReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PatchClubInfoReq.java
@@ -3,6 +3,12 @@ package com.example.relayRun.club.dto;
 import com.example.relayRun.util.GoalType;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
+import org.hibernate.validator.constraints.Range;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
 
 @Getter
 @Setter
@@ -10,24 +16,30 @@ import lombok.*;
 @AllArgsConstructor
 public class PatchClubInfoReq {
     @ApiModelProperty(example="그룹 이름", required = true)
+    @NotBlank @Size(max = 20)
     private String name;
 
     @ApiModelProperty(example="그룹 소개", required = true)
+    @NotNull @Size(max = 50)
     private String content;
 
     @ApiModelProperty(example="그룹 대표 이미지", required = true)
+    @NotNull
     private String imgURL;
 
     @ApiModelProperty(example="최대 인원 수", required = true)
+    @NotNull @Range(min = 1, max = 8)
     private Integer maxNum;
 
     @ApiModelProperty(example="난이도", required = true)
+    @NotNull @Range(min = 0, max = 3)
     private Integer level;
 
     @ApiModelProperty(example="목표 종류")
     private GoalType goalType;
 
     @ApiModelProperty(example="목표 km")
+    @Positive
     private Float goal;
 
     @ApiModelProperty(value = "변경할 모집 상태")

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PatchDeleteMemberReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PatchDeleteMemberReq.java
@@ -4,14 +4,16 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
+import javax.validation.constraints.Positive;
 import java.util.List;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ApiModel(value = "멤버 강퇴 모델")
+@ApiModel(value = "멤버 강퇴 / 그룹 나가기 모델")
 public class PatchDeleteMemberReq {
-    @ApiModelProperty(example = "강퇴 유저 프로필 idx", required = true)
+    @ApiModelProperty(example = "유저 프로필 idx", required = true)
+    @Positive
     private Long userProfileIdx;
 }

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PatchHostReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PatchHostReq.java
@@ -6,11 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.validation.constraints.Positive;
+
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class PatchHostReq {
     @ApiModelProperty(value = "차기 방장 프로필 아이디")
+    @Positive
     private Long nextHostProfileIdx;
 }

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PostClubReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PostClubReq.java
@@ -52,7 +52,6 @@ public class PostClubReq {
     private GoalType goalType;
 
     @ApiModelProperty(example="목표치 Float | 거리 단위 : km, 시간 단위 : 초")
-    @Positive
     private Float goal;
 
     @ApiModelProperty(required = true)

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PostClubReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PostClubReq.java
@@ -1,6 +1,5 @@
 package com.example.relayRun.club.dto;
 
-import com.example.relayRun.user.entity.UserProfileEntity;
 import com.example.relayRun.util.GoalType;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -8,7 +7,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Range;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Getter
@@ -17,34 +21,41 @@ import java.util.List;
 @AllArgsConstructor
 @ApiModel(value = "그룹 생성 Model", description = "hostIdx는 그룹을 만드려고 하는 유저의 프로필 식별자를 넣으면 됩니다!")
 public class PostClubReq {
-
     @ApiModelProperty(example="그룹 식별자", hidden = true)
     private Long clubIdx;
 
     @ApiModelProperty(example="그룹 이름", required = true)
+    @NotBlank @Size(max = 20)
     private String name;
 
     @ApiModelProperty(example="그룹 소개", required = true)
+    @NotNull @Size(max = 50)
     private String content;
 
     @ApiModelProperty(example="그룹 대표 이미지", required = true)
+    @NotNull
     private String imgURL;
 
     @ApiModelProperty(example="방장 식별자 (현재 유저의 프로필 식별자)", required = true)
+    @NotNull
     private Long hostIdx;
 
     @ApiModelProperty(example="최대 인원 수 | Integer", required = true)
+    @NotNull @Range(min = 1, max = 8)
     private Integer maxNum;
 
     @ApiModelProperty(example="난이도 | Integer | 전체 : 0, 초급 : 1, 중급 : 2, 상급 : 3", required = true)
+    @NotNull @Range(min = 0, max = 3)
     private Integer level;
 
     @ApiModelProperty(example="그룹 목표 종류 | String | 목표 없음 : NOGOAL, 거리 : DISTANCE, 시간 : TIME")
     private GoalType goalType;
 
     @ApiModelProperty(example="목표치 Float | 거리 단위 : km, 시간 단위 : 초")
+    @Positive
     private Float goal;
 
     @ApiModelProperty(required = true)
+    @NotNull @Size(min = 1)
     private List<TimeTableDTO> timeTable;
 }

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PostMemberStatusReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PostMemberStatusReq.java
@@ -4,6 +4,9 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Getter
@@ -13,8 +16,10 @@ import java.util.List;
 @ApiModel(value = "그룹 신청 / 시간표 등록 요청 Model")
 public class PostMemberStatusReq {
     @ApiModelProperty(example = "유저의 프로필 인덱스")
+    @Positive
     private Long userProfileIdx;
 
     @ApiModelProperty(example = "시간표 정보")
+    @NotNull @Size(min = 1)
     private List<TimeTableDTO> timeTables;
 }

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PostTimeTableReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PostTimeTableReq.java
@@ -4,6 +4,8 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Getter
@@ -13,5 +15,6 @@ import java.util.List;
 @ApiModel(value = "시간표 등록 요청 Model")
 public class PostTimeTableReq {
     @ApiModelProperty(example = "시간표 정보")
+    @NotNull @Size(min = 1)
     private List<TimeTableDTO> timeTables;
 }

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/TimeTableDTO.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/TimeTableDTO.java
@@ -4,6 +4,11 @@ import com.example.relayRun.util.GoalType;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
+import org.hibernate.validator.constraints.Range;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
 import java.time.LocalTime;
 
 @Getter
@@ -12,17 +17,21 @@ import java.time.LocalTime;
 @NoArgsConstructor
 public class TimeTableDTO {
     @ApiModelProperty(example = "요일 | Integer | 월 : 1, ... 일 : 7")
+    @NotNull @Range(min = 1, max = 7)
     private Integer day;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone = "Asia/Seoul")
     @ApiModelProperty(example = "시작 시간 | String | HH:mm:ss")
+    @NotNull @Pattern(regexp = "^\\d{2}:\\d{2}:\\d{2}$")
     private LocalTime start;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone = "Asia/Seoul")
     @ApiModelProperty(example = "종료 시간 | String | HH:mm:ss")
+    @NotNull @Pattern(regexp = "^\\d{2}:\\d{2}:\\d{2}$")
     private LocalTime end;
 
     @ApiModelProperty(example = "목표치 | Float | 거리 : km, 시간 : 초")
+    @Positive
     private Float goal;
 
     @ApiModelProperty(example = "목표 종류 | String | 목표 없음 : NOGOAL, 거리 : DISTANCE, 시간 : TIME")

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/TimeTableDTO.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/TimeTableDTO.java
@@ -31,7 +31,6 @@ public class TimeTableDTO {
     private LocalTime end;
 
     @ApiModelProperty(example = "목표치 | Float | 거리 : km, 시간 : 초")
-    @Positive
     private Float goal;
 
     @ApiModelProperty(example = "목표 종류 | String | 목표 없음 : NOGOAL, 거리 : DISTANCE, 시간 : TIME")

--- a/relayRun/src/main/java/com/example/relayRun/club/repository/ClubRepository.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/repository/ClubRepository.java
@@ -12,9 +12,11 @@ import java.util.Optional;
 public interface ClubRepository extends JpaRepository <ClubEntity, Long> {
     List<GetClubListRes> findByStatusOrderByCreatedAtDesc(String status);
     List<GetClubListRes> findByNameContainingAndStatusOrderByCreatedAtDesc(String search, String status);
+    Optional<ClubEntity> findByClubIdxAndRecruitStatusAndStatus(Long id, String recruitStatus, String status);
+    Optional<ClubEntity> findByClubIdxAndStatus(Long id, String status);
+
     Optional<ClubEntity> findByClubIdx(Long clubIdx);
     List<GetClubListRes> findByOrderByRecruitStatusDesc();
     List<ClubEntity> findAll();
     List<GetClubListRes> findByNameContaining(String search);
-    Optional<ClubEntity> findByClubIdxAndStatus(Long id, String status);
 }

--- a/relayRun/src/main/java/com/example/relayRun/club/repository/ClubRepository.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/repository/ClubRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 @Repository
 public interface ClubRepository extends JpaRepository <ClubEntity, Long> {
+    List<GetClubListRes> findByStatusOrderByCreatedAtDesc(String status);
+    List<GetClubListRes> findByNameContainingAndStatusOrderByCreatedAtDesc(String search, String status);
     Optional<ClubEntity> findByClubIdx(Long clubIdx);
     List<GetClubListRes> findByOrderByRecruitStatusDesc();
     List<ClubEntity> findAll();

--- a/relayRun/src/main/java/com/example/relayRun/club/repository/ClubRepository.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/repository/ClubRepository.java
@@ -14,9 +14,4 @@ public interface ClubRepository extends JpaRepository <ClubEntity, Long> {
     List<GetClubListRes> findByNameContainingAndStatusOrderByCreatedAtDesc(String search, String status);
     Optional<ClubEntity> findByClubIdxAndRecruitStatusAndStatus(Long id, String recruitStatus, String status);
     Optional<ClubEntity> findByClubIdxAndStatus(Long id, String status);
-
-    Optional<ClubEntity> findByClubIdx(Long clubIdx);
-    List<GetClubListRes> findByOrderByRecruitStatusDesc();
-    List<ClubEntity> findAll();
-    List<GetClubListRes> findByNameContaining(String search);
 }

--- a/relayRun/src/main/java/com/example/relayRun/club/repository/MemberStatusRepository.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/repository/MemberStatusRepository.java
@@ -12,9 +12,10 @@ import java.util.List;
 
 @Repository
 public interface MemberStatusRepository extends JpaRepository<MemberStatusEntity, Long> {
+    Optional<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndApplyStatusAndStatus(Long userProfileIdx, String applyStatus, String status);
+
     List<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndStatus(Long userProfileIdx, String status);
     Optional<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndApplyStatusIs(Long userProfileIdx, String applyStatus);
-    Optional<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndApplyStatusAndStatus(Long userProfileIdx, String applyStatus, String status);
     @Query(value = "select member_status_idx from member_status where club_idx = :clubIdx", nativeQuery = true)
     List<Long> selectMemberStatusIdxList(@Param(value = "clubIdx") Long clubIdx);
 

--- a/relayRun/src/main/java/com/example/relayRun/club/repository/MemberStatusRepository.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/repository/MemberStatusRepository.java
@@ -13,22 +13,12 @@ import java.util.List;
 @Repository
 public interface MemberStatusRepository extends JpaRepository<MemberStatusEntity, Long> {
     Optional<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndApplyStatusAndStatus(Long userProfileIdx, String applyStatus, String status);
-
-    List<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndStatus(Long userProfileIdx, String status);
-    Optional<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndApplyStatusIs(Long userProfileIdx, String applyStatus);
-    @Query(value = "select member_status_idx from member_status where club_idx = :clubIdx", nativeQuery = true)
-    List<Long> selectMemberStatusIdxList(@Param(value = "clubIdx") Long clubIdx);
-
-    List<MemberStatusEntity> findByClubIdx_ClubIdx(Long clubIdx);
-
-    List<MemberStatusEntity> findAllByClubIdx_ClubIdxAndApplyStatusAndStatus(Long clubIdx, String applyStatus, String status);
-
-    @Query(value = "select * from member_status where user_profile_idx = :userProfileIdx limit 1", nativeQuery = true)
-    MemberStatusEntity findByUserProfileIdx(Long userProfileIdx);
-
-    List<MemberStatusEntity> findByClubIdxAndStatus(ClubEntity club, String status);
-
-    
+    Optional<MemberStatusEntity> findByMemberStatusIdxAndApplyStatusAndStatus(Long memberStatusIdx, String applyStatus, String status);
     Optional<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndClubIdx_ClubIdxAndApplyStatusAndStatus(Long userProfileIdx, Long clubIdx, String applyStatus, String status);
 
+    List<MemberStatusEntity> findByUserProfileIdx_UserProfileIdxAndStatus(Long userProfileIdx, String status);
+    List<MemberStatusEntity> findAllByClubIdx_ClubIdxAndApplyStatusAndStatus(Long clubIdx, String applyStatus, String status);
+    @Query(value = "select * from member_status where user_profile_idx = :userProfileIdx limit 1", nativeQuery = true)
+    MemberStatusEntity findByUserProfileIdx(Long userProfileIdx);
+    List<MemberStatusEntity> findByClubIdxAndStatus(ClubEntity club, String status);
 }

--- a/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
@@ -84,26 +84,31 @@ public class ClubService {
     }
 
     public List<GetMemberOfClubRes> getMemberOfClub(Long clubIdx) throws BaseException {
-        List<MemberStatusEntity> memberStatusEntityList = memberStatusRepository.findAllByClubIdx_ClubIdxAndApplyStatusAndStatus(clubIdx, "ACCEPTED", "active");
-        if (memberStatusEntityList.isEmpty()) {
-            throw new BaseException(BaseResponseStatus.FAILED_TO_SEARCH);
+        try {
+            List<MemberStatusEntity> memberStatusEntityList = memberStatusRepository.findAllByClubIdx_ClubIdxAndApplyStatusAndStatus(clubIdx, "ACCEPTED", "active");
+            if (memberStatusEntityList.isEmpty()) {
+                throw new BaseException(BaseResponseStatus.FAILED_TO_SEARCH);
+            }
+
+            List<GetMemberOfClubRes> res = new ArrayList<>();
+            for (MemberStatusEntity memberStatusEntity : memberStatusEntityList) {
+                UserProfileEntity userProfileEntity = memberStatusEntity.getUserProfileIdx();
+                GetMemberProfileRes getMemberProfileRes = GetMemberProfileRes.builder()
+                        .userProfileIdx(userProfileEntity.getUserProfileIdx())
+                        .nickname(userProfileEntity.getNickName())
+                        .statusMsg(userProfileEntity.getStatusMsg())
+                        .imgUrl(userProfileEntity.getImgURL())
+                        .build();
+                GetMemberOfClubRes getMemberOfClubRes = GetMemberOfClubRes.builder()
+                        .memberStatusIdx(memberStatusEntity.getMemberStatusIdx())
+                        .userProfile(getMemberProfileRes)
+                        .build();
+                res.add(getMemberOfClubRes);
+            }
+            return res;
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
-        List<GetMemberOfClubRes> res = new ArrayList<>();
-        for (MemberStatusEntity memberStatusEntity : memberStatusEntityList) {
-            UserProfileEntity userProfileEntity = memberStatusEntity.getUserProfileIdx();
-            GetMemberProfileRes getMemberProfileRes = GetMemberProfileRes.builder()
-                    .userProfileIdx(userProfileEntity.getUserProfileIdx())
-                    .nickname(userProfileEntity.getNickName())
-                    .statusMsg(userProfileEntity.getStatusMsg())
-                    .imgUrl(userProfileEntity.getImgURL())
-                    .build();
-            GetMemberOfClubRes getMemberOfClubRes = GetMemberOfClubRes.builder()
-                    .memberStatusIdx(memberStatusEntity.getMemberStatusIdx())
-                    .userProfile(getMemberProfileRes)
-                    .build();
-            res.add(getMemberOfClubRes);
-        }
-        return res;
     }
 
     public GetClubDetailRes getClubDetail(Long clubIdx) throws BaseException {

--- a/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
@@ -29,24 +29,20 @@ public class ClubService {
     private final UserProfileRepository userProfileRepository;
     private final MemberStatusRepository memberStatusRepository;
     private final MemberStatusService memberStatusService;
-    private final RunningRecordService runningRecordService;
 
     public ClubService(ClubRepository clubRepository,
                        UserRepository userRepository,
                        UserProfileRepository userProfileRepository,
                        MemberStatusRepository memberStatusRepository,
-                       MemberStatusService memberStatusService,
-                       RunningRecordService runningRecordService) {
+                       MemberStatusService memberStatusService) {
         this.clubRepository = clubRepository;
         this.userRepository = userRepository;
         this.userProfileRepository = userProfileRepository;
         this.memberStatusRepository = memberStatusRepository;
         this.memberStatusService = memberStatusService;
-        this.runningRecordService = runningRecordService;
     }
 
-    @Transactional
-    public List<GetMemberOfClubRes> getHome(Principal principal, Long userProfileIdx) throws BaseException {
+    public Long getClubIdx(Principal principal, Long userProfileIdx) throws BaseException {
         Optional<UserEntity> optionalUserEntity = userRepository.findByEmail(principal.getName());
         if (optionalUserEntity.isEmpty()) {
             throw new BaseException(BaseResponseStatus.FAILED_TO_LOGIN);
@@ -68,18 +64,7 @@ public class ClubService {
             throw new BaseException(BaseResponseStatus.INVALID_MEMBER_STATUS);
         }
 
-        Long clubIdx = memberStatusEntity.get().getClubIdx().getClubIdx();
-        List<GetMemberOfClubRes> getMemberOfClubResList = getMemberOfClub(clubIdx);
-
-        for(GetMemberOfClubRes getMemberOfClubRes : getMemberOfClubResList) {
-            LocalDate date = LocalDate.now();
-//            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-//            LocalDateTime startDate = LocalDateTime.parse(date + " 00:00:00", formatter);
-//            LocalDateTime endDate = LocalDateTime.parse(date + " 23:59:59", formatter);
-            getMemberOfClubRes.setRunningRecord(runningRecordService.getRecordWithoutLocation(getMemberOfClubRes.getMemberStatusIdx(), date.atStartOfDay(), date.plusDays(1).atStartOfDay()));
-        }
-
-        return getMemberOfClubResList;
+        return memberStatusEntity.get().getClubIdx().getClubIdx();
     }
 
     public List<GetClubListRes> getClubs() throws BaseException {

--- a/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
@@ -84,7 +84,7 @@ public class ClubService {
 
     public List<GetClubListRes> getClubs() throws BaseException {
         try {
-            return clubRepository.findByOrderByRecruitStatusDesc();
+            return clubRepository.findByStatusOrderByCreatedAtDesc("active");
         } catch (Exception e) {
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
@@ -92,9 +92,8 @@ public class ClubService {
 
     public List<GetClubListRes> getClubsByName(String search) throws BaseException {
         try {
-            return clubRepository.findByNameContaining(search);
+            return clubRepository.findByNameContainingAndStatusOrderByCreatedAtDesc(search, "active");
         } catch (Exception e) {
-            e.printStackTrace();
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
     }

--- a/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
@@ -112,21 +112,26 @@ public class ClubService {
     }
 
     public GetClubDetailRes getClubDetail(Long clubIdx) throws BaseException {
-        Optional<ClubEntity> optional = clubRepository.findByClubIdxAndStatus(clubIdx, "active");
-        if (optional.isEmpty()) {
-            throw new BaseException(BaseResponseStatus.CLUB_UNAVAILABLE);
+        try {
+            Optional<ClubEntity> optional = clubRepository.findByClubIdxAndStatus(clubIdx, "active");
+            if (optional.isEmpty()) {
+                throw new BaseException(BaseResponseStatus.CLUB_UNAVAILABLE);
+            }
+
+            ClubEntity clubEntity = optional.get();
+            return GetClubDetailRes.builder()
+                    .clubIdx(clubEntity.getClubIdx())
+                    .imgURL(clubEntity.getImgURL())
+                    .name(clubEntity.getName())
+                    .content(clubEntity.getContent())
+                    .hostIdx(clubEntity.getHostIdx().getUserProfileIdx())
+                    .level(clubEntity.getLevel())
+                    .goalType(clubEntity.getGoalType())
+                    .goal(clubEntity.getGoal())
+                    .build();
+        } catch(Exception e) {
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
-        ClubEntity clubEntity = optional.get();
-        return GetClubDetailRes.builder()
-                .clubIdx(clubEntity.getClubIdx())
-                .imgURL(clubEntity.getImgURL())
-                .name(clubEntity.getName())
-                .content(clubEntity.getContent())
-                .hostIdx(clubEntity.getHostIdx().getUserProfileIdx())
-                .level(clubEntity.getLevel())
-                .goalType(clubEntity.getGoalType())
-                .goal(clubEntity.getGoal())
-                .build();
     }
 
     @Transactional

--- a/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
@@ -139,7 +139,6 @@ public class ClubService {
                 .build();
     }
 
-    // 그룹 생성
     @Transactional
     public void makesClub(Principal principal, PostClubReq clubReq) throws BaseException {
         Optional<UserEntity> optionalUserEntity = userRepository.findByEmail(principal.getName());
@@ -158,12 +157,13 @@ public class ClubService {
             throw new BaseException(BaseResponseStatus.POST_USERS_PROFILES_EQUALS);
         }
 
-        if (clubReq.getName().isEmpty()) {
-            throw new BaseException(BaseResponseStatus.POST_CLUBS_NAME_EMPTY);
-        }
-        if (clubReq.getContent().isEmpty()) {
-            throw new BaseException(BaseResponseStatus.POST_CLUBS_CONTENTS_EMPTY);
-        }
+//        if (clubReq.getName().isEmpty()) {
+//            throw new BaseException(BaseResponseStatus.POST_CLUBS_NAME_EMPTY);
+//        }
+//        if (clubReq.getContent().isEmpty()) {
+//            throw new BaseException(BaseResponseStatus.POST_CLUBS_CONTENTS_EMPTY);
+//        }
+
         ClubEntity clubEntity = ClubEntity.builder()
                 .name(clubReq.getName())
                 .content(clubReq.getContent())
@@ -184,7 +184,7 @@ public class ClubService {
 
         memberStatusRepository.save(memberStatusEntity);
 
-        memberStatusService.createTimeTable(memberStatusEntity.getMemberStatusIdx(), clubReq.getTimeTable());
+        memberStatusService.createTimeTable(memberStatusEntity, clubReq.getTimeTable());
     }
 
     @Transactional

--- a/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
@@ -69,9 +69,10 @@ public class RunningRecordService {
      */
     public PostRunningInitRes startRunning(Principal principal, PostRunningInitReq runningInitReq) throws BaseException {
         try{
-            Optional<MemberStatusEntity> optionalMemberStatus = memberStatusRepository.findByUserProfileIdx_UserProfileIdxAndApplyStatusIs(
+            Optional<MemberStatusEntity> optionalMemberStatus = memberStatusRepository.findByUserProfileIdx_UserProfileIdxAndApplyStatusAndStatus(
                     runningInitReq.getProfileIdx(),
-                    "ACCEPTED"
+                    "ACCEPTED",
+                    "active"
             );
             if (optionalMemberStatus.isEmpty())
                 throw new BaseException(BaseResponseStatus.POST_RECORD_INVALID_CLUB_ACCESS);

--- a/relayRun/src/main/java/com/example/relayRun/util/BaseResponseStatus.java
+++ b/relayRun/src/main/java/com/example/relayRun/util/BaseResponseStatus.java
@@ -62,6 +62,8 @@ public enum BaseResponseStatus {
 
     SOCIAL(false, 5001, "소셜로 로그인을 진행한 이메일 입니다."),
     NOT_SOCIAL(false, 2001, "소셜이 로그인으로 진행한 이메일입니다."),
+
+    VALIDATION_ERROR(false, 4000, "유효하지 않은 입력 값입니다."),
     /*
      * 5000: database error
      * */


### PR DESCRIPTION
- 조회 시 status 확인
   - club 조회 시 status=active, memberstatus 조회 시 applystatus=accepted & status=active(사실상 무의미)인 데이터만 조회하도록 수정
   - **timetable 접근 전 memberstatus 먼저 조회** 확인 부탁드립니다
   - 삭제 된 그룹이나 memberstatus가 살아있지 않은 경우도 조회하는 경우가 있다고 생각해서(기록 부분이나 유저 부분) user/record 단은 명백히 고쳐야 하는 부분 제외 수정하지 않았습니다.
   - 그룹 신청 시에는 club의 recruitstatus 추가적으로 확인하도록 수정했습니다.

- 트랜잭션
   - 작동하도록 수정했습니다. 유의미한 곳에만 적용됩니다.

- 그룹 나가기 API
   - 추가했습니다. `status = "LEFT"`로 우선 넣었는데.. 괜찮나요? 아니면 수정하겠습니다

- validation
   - DTO 입력 값의 유효성 검사 추가했습니다. 디코에 말했듯이 VALIDATION_ERROR로 한 번에 쏴주고 있어요
   - 그 외 예외처리 쫌쫌따리 했습니다

- 그룹 신청, 개인 시간표 조회, 시간표 수정에 access 토큰 받도록 수정했습니다.

- 고려할 부분
   - **그룹 삭제 시 memberstatus**도 죽여야할 것 같아요
   - recruit status 변경 API를 합치면 어떨까요? 요청 들어왔을 때 a면 b로 변경 b면 a로 변경하게요
   - 수정 후 모든 API 확인해 봤는데 **patch 요청에 principal이 들어오지 않아요**. 뭐가 문제일까요?