### PR TITLE
Issue 97: 기록 조회 예외처리 및 달리기 제한

### DIFF
--- a/relayRun/src/main/java/com/example/relayRun/club/controller/MemberStatusController.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/controller/MemberStatusController.java
@@ -61,7 +61,10 @@ public class MemberStatusController {
             return new BaseResponse<>(e.getStatus());
         }
     }
-    @ApiOperation(value = "시간표 수정", notes = "path variable로 수정하고자 하는 유저의 userProfileIdx, body로는 해당 유저의 시간표 정보를 리스트 형식으로 보내면 시간표 수정이 완료됩니다.")
+    @ApiOperation(value = "시간표 수정", notes = "path variable로 수정하고자 하는 유저의 userProfileIdx, body로는 해당 유저의 시간표 정보를 리스트 형식으로 보내면 시간표 수정이 완료됩니다."
+            + "\n\n기존 시간표는 삭제되므로, 특정 날만 수정을 원할 경우 그 날의 수정사항과 원래 있던 정보를 다 전달해주셔야 합니다.\n" +
+            "ex) 월수금 10~12로 등록되어있는 것 중 월요일만 12~14로 바꾸고 싶을 경우,\n" +
+            "월요일 12~14, 수요일 10~12, 금요일 10~12로 전부 보내주셔야 합니다.")
     @ResponseBody
     @PostMapping("/time-tables/{userProfileIdx}")
     public BaseResponse<String> updateTimeTable(

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PostTimeTableReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PostTimeTableReq.java
@@ -12,6 +12,5 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ApiModel(value = "시간표 등록 요청 Model")
 public class PostTimeTableReq {
-    @ApiModelProperty(example = "시간표 정보")
     private List<TimeTableDTO> timeTables;
 }

--- a/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
@@ -12,8 +12,8 @@ import com.example.relayRun.user.repository.UserProfileRepository;
 import com.example.relayRun.user.repository.UserRepository;
 import com.example.relayRun.util.BaseException;
 import com.example.relayRun.util.BaseResponseStatus;
-import org.hibernate.NonUniqueResultException;
 import com.example.relayRun.record.service.RunningRecordService;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -224,7 +224,7 @@ public class ClubService {
 
         } catch (BaseException e) {
             throw new BaseException(e.getStatus());
-        } catch (NonUniqueResultException e) { // 두개 이상의 그룹에 들어가있는 비정상 상황
+        } catch (IncorrectResultSizeDataAccessException e) { // 두개 이상의 그룹에 들어가있는 비정상 상황
             throw new BaseException(BaseResponseStatus.ERROR_DUPLICATE_CLUB);
         } catch (Exception e) {
             throw new BaseException(BaseResponseStatus.POST_CLUBS_FAIL);

--- a/relayRun/src/main/java/com/example/relayRun/club/service/MemberStatusService.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/service/MemberStatusService.java
@@ -14,7 +14,7 @@ import com.example.relayRun.user.repository.UserRepository;
 import com.example.relayRun.util.BaseException;
 import com.example.relayRun.util.BaseResponseStatus;
 import com.example.relayRun.util.RecordDataHandler;
-import org.hibernate.NonUniqueResultException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,7 +87,7 @@ public class MemberStatusService {
 
         } catch (BaseException e) { // profile 존재 x, 그룹 존재 x, 시간표 등록 실패일 경우
             throw new BaseException(e.getStatus());
-        } catch (NonUniqueResultException e) { // 두개 이상의 그룹에 들어가있는 비정상 상황
+        } catch (IncorrectResultSizeDataAccessException e) { // 두개 이상의 그룹에 들어가있는 비정상 상황
             throw new BaseException(BaseResponseStatus.ERROR_DUPLICATE_CLUB);
         } catch (Exception e) { // 이외의 경우 에러처리
             throw new BaseException(BaseResponseStatus.POST_MEMBER_STATUS_FAIL);

--- a/relayRun/src/main/java/com/example/relayRun/record/controller/RunningRecordController.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/controller/RunningRecordController.java
@@ -58,7 +58,7 @@ public class RunningRecordController {
     }
 
     // profile idx와 오늘 날짜로 조회
-    @ApiOperation(value="해당 프로필 일별 기록 조회", notes="위치 원할시 token 필요, query로는 프로필 idx, date를 입력해주세요 ex) record/?idx=1&date=2023-01-26\n" +
+    @ApiOperation(value="프로필 데일리 기록 조회", notes="위치 원할시 token 필요, query로는 프로필 idx, date를 입력해주세요 ex) record/?idx=1&date=2023-01-26\n" +
             "token이 없거나 해당 유저가 아닐 때는 위치 list가 null로 반환됩니다!")
     @ResponseBody
     @GetMapping("")
@@ -74,6 +74,52 @@ public class RunningRecordController {
             return new BaseResponse(e.getStatus());
         }
     }
+
+    @ApiOperation(value="그룹 데일리 기록 조회", notes="조회할 그룹 idx를 입력해주세요, query에 조회 날짜를 입력해주세요 ex record/summary/club/?clubIdx=1&date=2023-01-27")
+    @GetMapping("/summary/club")
+    public BaseResponse<GetDailyRes> getDailyGroup(
+            @ApiParam(value = "조회하고자 하는 그룹의 식별자")@RequestParam("clubIdx") Long clubIdx,
+            @ApiParam(value = "조회 날짜 | String | yyyy-MM-dd")@RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
+    ) {
+        try {
+            GetDailyRes dailyGroup = runningRecordService.getDailyGroup(clubIdx, date);
+            return new BaseResponse<>(dailyGroup);
+        } catch (BaseException e) {
+            return new BaseResponse(e.getStatus());
+        }
+    }
+
+    @ApiOperation(value="프로필 데일리 기록 조회", notes="조회할 프로필 idx, 년과 월을 입력해주세요 ex record/calender/?profileIdx=1&year=2023&month=1")
+    @GetMapping("/calender")
+    public BaseResponse<List<GetCalender>> getCalender(
+            @ApiParam(value = "조회하고자 하는 유저의 프로필 식별자")@RequestParam("profileIdx") Long profileIdx,
+            @ApiParam(value = "년 | Integer")@RequestParam("year") Integer year,
+            @ApiParam(value = "월 | Integer")@RequestParam("month") Integer month
+    ) {
+        try {
+            List<GetCalender> calender = runningRecordService.getCalender(profileIdx, year, month);
+            return new BaseResponse<>(calender);
+        } catch (BaseException e) {
+            return new BaseResponse(e.getStatus());
+        }
+    }
+
+    @ApiOperation(value="그룹 먼슬리 기록 조회", notes="조회할 그룹 idx, 년과 월을 입력해주세요 ex record/calender/club/?clubIdx=1&year=2023&month=1")
+    @GetMapping("/calender/club")
+    public BaseResponse<List<GetCalender>> getClubCalender(
+            @ApiParam(value = "조회하고자 하는 그룹의 식별자")@RequestParam("clubIdx") Long clubIdx,
+            @ApiParam(value = "년 | Integer")@RequestParam("year") Integer year,
+            @ApiParam(value = "월 | Integer")@RequestParam("month") Integer month
+    ) {
+        try {
+            List<GetCalender> calender = runningRecordService.getClubCalender(clubIdx, year, month);
+            return new BaseResponse<>(calender);
+        } catch (BaseException e) {
+            return new BaseResponse(e.getStatus());
+        }
+    }
+
+    // ----------------------------------------------------------------------------
 
     // 기록 세부 조회
     @ApiOperation(value="기록 idx로 조회 -> 임시, 날짜별 조회를 이용", notes="path variable에 조회할 기록의 idx를 입력해주세요")
@@ -103,47 +149,4 @@ public class RunningRecordController {
         }
     }
 
-    @ApiOperation(value="해당 그룹 일별 기록 조회", notes="조회할 그룹 idx를 입력해주세요, query에 조회 날짜를 입력해주세요 ex record/summary/club/?clubIdx=1&date=2023-01-27")
-    @GetMapping("/summary/club")
-    public BaseResponse<GetDailyRes> getDailyGroup(
-            @ApiParam(value = "조회하고자 하는 그룹의 식별자")@RequestParam("clubIdx") Long clubIdx,
-            @ApiParam(value = "조회 날짜 | String | yyyy-MM-dd")@RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
-    ) {
-        try {
-            GetDailyRes dailyGroup = runningRecordService.getDailyGroup(clubIdx, date);
-            return new BaseResponse<>(dailyGroup);
-        } catch (BaseException e) {
-            return new BaseResponse(e.getStatus());
-        }
-    }
-
-    @ApiOperation(value="해당 프로필의 월별 기록 조회", notes="조회할 프로필 idx, 년과 월을 입력해주세요 ex record/calender/?profileIdx=1&year=2023&month=1")
-    @GetMapping("/calender")
-    public BaseResponse<List<GetCalender>> getCalender(
-            @ApiParam(value = "조회하고자 하는 유저의 프로필 식별자")@RequestParam("profileIdx") Long profileIdx,
-            @ApiParam(value = "년 | Integer")@RequestParam("year") Integer year,
-            @ApiParam(value = "월 | Integer")@RequestParam("month") Integer month
-    ) {
-        try {
-            List<GetCalender> calender = runningRecordService.getCalender(profileIdx, year, month);
-            return new BaseResponse<>(calender);
-        } catch (BaseException e) {
-            return new BaseResponse(e.getStatus());
-        }
-    }
-
-    @ApiOperation(value="해당 그룹의 월별 기록 조회", notes="조회할 그룹 idx, 년과 월을 입력해주세요 ex record/calender/club/?clubIdx=1&year=2023&month=1")
-    @GetMapping("/calender/club")
-    public BaseResponse<List<GetCalender>> getClubCalender(
-            @ApiParam(value = "조회하고자 하는 그룹의 식별자")@RequestParam("clubIdx") Long clubIdx,
-            @ApiParam(value = "년 | Integer")@RequestParam("year") Integer year,
-            @ApiParam(value = "월 | Integer")@RequestParam("month") Integer month
-    ) {
-        try {
-            List<GetCalender> calender = runningRecordService.getClubCalender(clubIdx, year, month);
-            return new BaseResponse<>(calender);
-        } catch (BaseException e) {
-            return new BaseResponse(e.getStatus());
-        }
-    }
 }

--- a/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
@@ -31,6 +31,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.time.LocalTime;
 import java.util.Optional;
@@ -90,6 +91,12 @@ public class RunningRecordService {
             if (!userEntityPrincipal.getUserIdx().equals(userProfileParam.getUserIdx().getUserIdx()))
                 throw new BaseException(BaseResponseStatus.POST_RECORD_NOT_MATCH_PARAM_PRINCIPAL);
             MemberStatusEntity memberStatus = optionalMemberStatus.get();
+
+            // 오늘 뛴 기록이 있는지 확인
+            Optional<Long> recordIdx = runningRecordRepository.selectByMemberStatusAndDateAndStatus(Arrays.asList(memberStatus), LocalDate.now(), "active");
+            if (!recordIdx.isEmpty()) {
+                throw new BaseException(BaseResponseStatus.POST_RECORD_ALREADY_RUN);
+            }
 
             Optional<TimeTableEntity> optionalTimeTable = timeTableRepository.findByMemberStatusIdxAndDayAndStartLessThanEqualAndEndGreaterThanEqual(
                     memberStatus, RecordDataHandler.toIntDay(LocalDate.now().getDayOfWeek()), LocalTime.now(), LocalTime.now()

--- a/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
@@ -227,7 +227,7 @@ public class RunningRecordService {
         try {
             Optional<RunningRecordEntity> optRecord = runningRecordRepository.findByRunningRecordIdxAndStatus(idx, "active");
             if (optRecord.isEmpty()) {
-                throw new Exception("RECORD_UNAVAILABLE");
+                throw new BaseException(BaseResponseStatus.RECORD_UNAVAILABLE);
             }
 
             RunningRecordEntity record = optRecord.get();
@@ -269,13 +269,11 @@ public class RunningRecordService {
 
         } catch (NullPointerException e) { // principal이 없거나 형식에 맞지 않을 때
             throw new BaseException(BaseResponseStatus.WRONG_JWT_SIGN_TOKEN);
+        } catch (BaseException e) {
+            throw new BaseException(e.getStatus());
         } catch (Exception e) {
-            if (e.getMessage().equals("RECORD_UNAVAILABLE")) {
-                throw new BaseException(BaseResponseStatus.RECORD_UNAVAILABLE);
-            } else {
-                System.out.println("e = " + e);
-                throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
-            }
+            System.out.println("e = " + e);
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
     }
 
@@ -346,7 +344,7 @@ public class RunningRecordService {
         try {
             Optional<ClubEntity> club = clubRepository.findByClubIdxAndStatus(clubIdx, "active");
             if (club.isEmpty()) {
-                throw new Exception("CLUB_UNAVAILABLE");
+                throw new BaseException(BaseResponseStatus.CLUB_UNAVAILABLE);
             }
             List<MemberStatusEntity> statusList = memberStatusRepository.findByClubIdxAndStatus(club.get(), "active");
 
@@ -364,13 +362,13 @@ public class RunningRecordService {
 
             return dailyRes;
 
+        } catch (BaseException e) {
+            throw new BaseException(e.getStatus());
+        } catch (NullPointerException e) {
+            throw new BaseException(BaseResponseStatus.RECORD_UNAVAILABLE);
         } catch (Exception e) {
-            if (e.getMessage().equals("CLUB_UNAVAILABLE")) {
-                throw new BaseException(BaseResponseStatus.CLUB_UNAVAILABLE);
-            } else {
-                System.out.println("e = " + e);
-                throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
-            }
+            System.out.println("e = " + e);
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
     }
 

--- a/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
@@ -21,6 +21,7 @@ import com.example.relayRun.util.RecordDataHandler;
 import org.hibernate.NonUniqueResultException;
 import org.locationtech.jts.io.ParseException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.Tuple;
@@ -286,9 +287,9 @@ public class RunningRecordService {
         } catch (BaseException e) {
             // 날짜에 해당하는 기록이 없을 때
             throw new BaseException((e.getStatus()));
-        } catch (NonUniqueResultException e) {
+        } catch (IncorrectResultSizeDataAccessException e) {
             // 같은 날짜에 두개 이상 기록이 있을 때
-            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
+            throw new BaseException(BaseResponseStatus.DUPLICATE_RECORD);
         }
     }
 

--- a/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
@@ -254,6 +254,8 @@ public class RunningRecordService {
                     .distance(record.getDistance())
                     .pace(record.getPace())
                     .goalStatus(record.getGoalStatus())
+                    .goalType(record.getGoalType())
+                    .goalValue(record.getGoal())
                     .locationList(locationList)
                     .build();
 
@@ -269,15 +271,6 @@ public class RunningRecordService {
         }
     }
 
-    public GetRecordByIdxRes setProfileGoalInfo(GetRecordByIdxRes recordByIdxRes, Long userProfileIdx, LocalDate date) {
-        Optional<MemberStatusEntity> optionalMemberStatusEntity = memberStatusRepository.findByUserProfileIdx_UserProfileIdxAndApplyStatusAndStatus(userProfileIdx, "ACCEPTED", "active");
-        Optional<TimeTableEntity> optionalTimeTableEntity = timeTableRepository.findByMemberStatusIdxAndDay(optionalMemberStatusEntity.get(), RecordDataHandler.toIntDay(date.getDayOfWeek()));
-        recordByIdxRes.setGoalType(optionalTimeTableEntity.get().getGoalType());
-        recordByIdxRes.setGoalValue(optionalTimeTableEntity.get().getGoal());
-        return recordByIdxRes;
-    }
-
-
     public GetRecordByIdxRes getRecordByDate(Principal principal, Long profileIdx, LocalDate date) throws BaseException {
         // 프로필이 속한 모든 지원 목록
         List<MemberStatusEntity> statusList = memberStatusRepository.findByUserProfileIdx_UserProfileIdxAndStatus(profileIdx, "active");
@@ -289,7 +282,6 @@ public class RunningRecordService {
                 throw new BaseException(BaseResponseStatus.RECORD_UNAVAILABLE);
             }
             GetRecordByIdxRes result = getRecordByIdx(principal, recordIdx.get());
-            result = setProfileGoalInfo(result, profileIdx, date);
             return result;
         } catch (BaseException e) {
             // 날짜에 해당하는 기록이 없을 때

--- a/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
+++ b/relayRun/src/main/java/com/example/relayRun/record/service/RunningRecordService.java
@@ -218,7 +218,7 @@ public class RunningRecordService {
 
 
     /**
-     * 기록 세부 조회 GET
+     * 기록 idx로 조회 GET
      * @param idx
      * @return
      * @throws BaseException
@@ -277,6 +277,14 @@ public class RunningRecordService {
         }
     }
 
+    /**
+     * 프로필 데일리 기록 GET
+     * @param principal
+     * @param profileIdx
+     * @param date
+     * @return
+     * @throws BaseException
+     */
     public GetRecordByIdxRes getRecordByDate(Principal principal, Long profileIdx, LocalDate date) throws BaseException {
         // 프로필이 속한 모든 지원 목록
         List<MemberStatusEntity> statusList = memberStatusRepository.findByUserProfileIdx_UserProfileIdxAndStatus(profileIdx, "active");
@@ -300,7 +308,7 @@ public class RunningRecordService {
 
 
     /**
-     * 개인 기록 일별 요약 GET (프로필이 많아지는 경우에만 사용)
+     * 개인 기록 일별 요약 GET (프로필이 많아지는 경우에만 사용, 지금은 사용 x)
      * @param principal
      * @param date
      * @return
@@ -335,7 +343,7 @@ public class RunningRecordService {
     }
 
     /**
-     * 그룹 기록 일별 요약 GET
+     * 그룹 기록 일별(데일리) 요약 GET
      * @param clubIdx
      * @param date
      * @return
@@ -413,6 +421,14 @@ public class RunningRecordService {
         }
     }
 
+    /**
+     * 그룹 먼슬리 GET
+     * @param clubIdx
+     * @param year
+     * @param month
+     * @return
+     * @throws BaseException
+     */
     public List<GetCalender> getClubCalender(Long clubIdx, Integer year, Integer month) throws BaseException {
         Optional<ClubEntity> club = clubRepository.findByClubIdxAndStatus(clubIdx, "active");
         if (club.isEmpty()) {

--- a/relayRun/src/main/java/com/example/relayRun/util/BaseResponseStatus.java
+++ b/relayRun/src/main/java/com/example/relayRun/util/BaseResponseStatus.java
@@ -49,6 +49,8 @@ public enum BaseResponseStatus {
     POST_RECORD_ALREADY_FINISH(false, 4904, "이미 끝난 기록입니다."),
     POST_RECORD_NO_PROFILE_IDX(false, 4905, "존재하지 않는 프로필 아이디입니다."),
     POST_RECORD_NOT_MATCH_PARAM_PRINCIPAL(false, 4906, "요청한 프로필 아이디와 로그인 아이디가 일치하지 않습니다."),
+    POST_RECORD_ALREADY_RUN(false, 4907, "이미 오늘 뛴 기록이 있습니다."),
+
     POST_USERS_INVALID_EMAIL(false, 5000, "이메일 양식이 맞지 않습니다."),
     POST_USERS_INVALID_PWD(false, 5001, "비밀번호 양식이 맞지 않습니다."),
     POST_REVIEW_IMG_ERROR(false, 5001, "리뷰 이미지 에러입니다."),

--- a/relayRun/src/main/java/com/example/relayRun/util/BaseResponseStatus.java
+++ b/relayRun/src/main/java/com/example/relayRun/util/BaseResponseStatus.java
@@ -20,6 +20,7 @@ public enum BaseResponseStatus {
     // 달리기단;
     RECORD_UNAVAILABLE(false, 2100,"기록이 존재하지 않습니다."),
     INVALID_DATE_FORMAT(false, 2101, "yyyy-mm-dd의 날짜 형식을 입력해주세요."),
+    DUPLICATE_RECORD(false, 2102, "해당 날짜에 기록이 두개 이상 존재합니다. (서버 문의)"),
 
     CLUB_UNAVAILABLE(false, 2200, "존재하지 않는 그룹입니다."),
     CLUB_CLOSED(false, 2201, "모집이 완료된 그룹입니다."),


### PR DESCRIPTION
수정사항
- 목표 종류 & 목표치를 레코드 테이블 컬럼에서 바로 갖고오도록 변경
- 하루에 한번만 달릴 수 있도록 제한
- 프로필 데일리 조회 시 기록 두개 이상인 날 예외처리
- 그룹 데일리 조회 시 기록 없는 날 예외처리
- NonUniqueResultException -> IncorrectResultSizeDataAccessException 일괄 변경
- 명세서 설명 추가(시간표 변경)

기록 조회 4가지 (프로필 데일리&먼슬리, 그룹 데일리&먼슬리) 다 제대로 작동되는지 검토 부탁드립니다!
예외처리된 내용은 아래와 같습니다
- 프로필 데일리: 해당 날짜에 기록이 없을 때, 두개 이상 있을 때
- 그룹 데일리: 해당 날짜에 기록이 없을 때
(먼슬리는 예외처리 없이, 기록이 있는 날짜들만 표시가 되고 그 달에 아무 기록도 없을 경우 빈 리스트가 반환됩니다.) 