### PR TITLE
Issue 102: 그룹 이미지 적용

### DIFF
--- a/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/controller/ClubController.java
@@ -68,9 +68,9 @@ public class ClubController {
             @ApiResponse(code = 404, message = "서버 문제 발생"),
             @ApiResponse(code = 500, message = "페이지를 찾을 수 없습니다")
     })
-    @ApiOperation(value="그룹 생성(방장)", notes="token 필요 / body에는 이름, 방장 idx, 소개, 이미지, 최대인원, 레벨, 목표 분류(선택), 목표치 입력\n" +
-
+    @ApiOperation(value="그룹 생성(방장)", notes="token 필요 / body에는 이름, 방장 idx, 소개, 최대인원, 레벨, 목표 분류(선택), 목표치 입력\n" +
             "hostIdx에는 그룹을 생성하려는 유저의 프로필 식별자값 (int)를 넣어주시면 됩니다!!\n" +
+            "대표 이미지는 디폴트 사진으로 적용되도록 변경하였습니다." +
             "timetable 예시는 디스코드에 적어두었습니다!")
     public BaseResponse<String> makeClub(
             Principal principal,

--- a/relayRun/src/main/java/com/example/relayRun/club/dto/PostClubReq.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/dto/PostClubReq.java
@@ -27,9 +27,6 @@ public class PostClubReq {
     @ApiModelProperty(example="그룹 소개", required = true)
     private String content;
 
-    @ApiModelProperty(example="그룹 대표 이미지", required = true)
-    private String imgURL;
-
     @ApiModelProperty(example="방장 식별자 (현재 유저의 프로필 식별자)", required = true)
     private Long hostIdx;
 

--- a/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
+++ b/relayRun/src/main/java/com/example/relayRun/club/service/ClubService.java
@@ -34,6 +34,8 @@ public class ClubService {
 
     private final RunningRecordService runningRecordService;
 
+    private String bucketURL = "https://team23-bucket.s3.ap-northeast-2.amazonaws.com/public/club";
+
     public ClubService(ClubRepository clubRepository, UserRepository userRepository, UserProfileRepository userProfileRepository,
                        MemberStatusRepository memberStatusRepository,
                        MemberStatusService memberStatusService, RunningRecordService runningRecordService) {
@@ -203,7 +205,7 @@ public class ClubService {
             ClubEntity clubEntity = ClubEntity.builder()
                     .name(clubReq.getName())
                     .content(clubReq.getContent())
-                    .imgURL(clubReq.getImgURL())
+                    .imgURL(bucketURL + "/yellow.png")
                     .hostIdx(userProfileEntity)
                     .maxNum(clubReq.getMaxNum())
                     .level(clubReq.getLevel())

--- a/relayRun/src/main/java/com/example/relayRun/user/service/UserService.java
+++ b/relayRun/src/main/java/com/example/relayRun/user/service/UserService.java
@@ -53,7 +53,7 @@ public class UserService {
 
     private RedisUtil redisUtil;
 
-    private String bucketURL = "https://runningmen-bucket.s3.ap-northeast-2.amazonaws.com";
+    private String bucketURL = "https://team23-bucket.s3.ap-northeast-2.amazonaws.com/public/profile";
 
     private HashMap<Integer, String> avatar = new HashMap<>() {{
         put(1, bucketURL + "/1.png");


### PR DESCRIPTION
그룹 생성 시 기본 이미지 적용

- 버킷에 그룹 이미지 올려서 [노란색 버전](https://team23-bucket.s3.ap-northeast-2.amazonaws.com/public/club/yellow.png) 으로 들어가도록 일괄 적용했습니다
- 그룹 생성 시 이미지 url은 더이상 받지 않습니다
- 이미 생성되어있는 그룹들도 이미지 URL 변경해두었습니다
- 프로필 이미지 경로도 동일한 버킷으로 수정했습니다